### PR TITLE
custom subdomain configuration

### DIFF
--- a/src/internalPages/ExtensionMain/MainScreen.tsx
+++ b/src/internalPages/ExtensionMain/MainScreen.tsx
@@ -112,6 +112,10 @@ const MainScreen: React.FC<Props> = ({classes}) => {
     )
   }
 
+  const renderHint = () => {
+  return <Typography>{"Place {ipfs} where the hash subdomain should be"}</Typography>
+  }
+
   const renderTextField = () => {
     if (!showTexField) return <> </>
     return (
@@ -119,12 +123,13 @@ const MainScreen: React.FC<Props> = ({classes}) => {
         <Typography variant="body2" className={classes.subtitle}>
           Gateway Base URL:
         </Typography>
+        {gatewayOption === ExtensionOptions.Local ? renderHint() : null}
         <TextField
           type="text"
           id="gatewayBaseURL"
           onChange={handleChangeGatewayBaseURL}
           value={gatewayBaseURL}
-          placeholder="Enter IPFS Gateway, localhost:5001"
+          placeholder="{ipfs}.gateway.com"
           className={classes.inputField}
           variant="filled"
         />

--- a/src/internalPages/ExtensionMain/MainScreen.tsx
+++ b/src/internalPages/ExtensionMain/MainScreen.tsx
@@ -113,7 +113,7 @@ const MainScreen: React.FC<Props> = ({classes}) => {
   }
 
   const renderHint = () => {
-  return <Typography>{"Place {ipfs} where the hash subdomain should be"}</Typography>
+  return <Typography>{"Place {ipfs} where the ipfs hash should go"}</Typography>
   }
 
   const renderTextField = () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,6 @@ export const ExtensionLabel: ExtensionOptionMessage = {
 };
 
 export const ExtensionURIMap: ExtensionURIMap = {
-  [ExtensionOptions.InfuraAPI]: 'ipfs.infura-ipfs.io',
-  [ExtensionOptions.IPFSNetwork]: 'ipfs.dweb.link',
+  [ExtensionOptions.InfuraAPI]: 'https://{ipfs}.ipfs.infura-ipfs.io',
+  [ExtensionOptions.IPFSNetwork]: 'https://{ipfs}.ipfs.dweb.link',
 };

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -40,33 +40,35 @@ export async function redirectToIpfs(domain: string) {
 
   try {
     const url = new URL(domain)
-    const ipfsHashPromise = resolution.ipfsHash(url.hostname)
     const gatewayBaseURL = (await chromeStorageSyncGet(StorageSyncKey.GatewayBaseURL)) ||
       'https://{ipfs}.ipfs.infura-ipfs.io';
-
-    let hash = await ipfsHashPromise;
+    let hash = await resolution.ipfsHash(url.hostname);
     if (isConvertableToV1base32Hash(hash, gatewayBaseURL)) {
       hash = new ipfsClient.CID(hash).toV1(); // convert to V1 base32 ipfs hash
     }
     const baseurl = placeIpfs(hash, gatewayBaseURL);
     const displayUrl = `${baseurl}/${url.pathname}`;
-    console.log(displayUrl);
     chrome.tabs.update({
       url: displayUrl,
     })
   } catch (err) {
     let message = err.message
     if (err instanceof ResolutionError) {
-      if (err.code === ResolutionErrorCode.RecordNotFound) {
-        const url = new URL(domain)
+      const url = new URL(domain)
+      console.log(err)
+      if (err.code === ResolutionErrorCode.RecordNotFound) {  
         const redirectUrl = await resolution
           .httpUrl(url.hostname)
-          .catch(err => undefined)
-        if (!redirectUrl)
-          chrome.tabs.update({
-            url: `https://unstoppabledomains.com/search?searchTerm=${url.hostname}&searchRef=chrome-extension`,
-          })
-        chrome.tabs.update({ url: redirectUrl })
+          .catch(error => undefined)
+        if (redirectUrl) chrome.tabs.update({ url: redirectUrl });
+        chrome.tabs.update({
+          url: `https://unstoppabledomains.com/search?searchTerm=${url.hostname}&searchRef=chrome-extension`,
+        });
+      }
+      if (err.code === ResolutionErrorCode.UnregisteredDomain) {
+        chrome.tabs.update({
+          url: `https://unstoppabledomains.com/search?searchTerm=${url.hostname}&searchRef=chrome-extension`,
+        });
       }
     }
     else chrome.tabs.update({ url: `index.html#error?reason=${message}` })


### PR DESCRIPTION
This should allow users to specify their local URLs in any format they want. Safe origin version means you have {ipfs} in front of the URL like `https://{ipfs}.ipfs.cf-ipfs.com`

This will trigger extension to convert ipfs hash to v1 base32 cid and place it as a subdomain in front. So the resulting URL is `https://bafybeihjxtxvifextn52v4bcr3d7suduenkby7lvnb4ybjvpxzujfg2f7e.ipfs.cf-ipfs.com/`

When URL like this `https://ipfs.io/ipfs/{ipfs}` will not trigger anything and just substitute ipfsHash from the blockchain instead of {ipfs}. So the resulting URL is  `https://ipfs.io/ipfs/Qme54oEzRkgooJbCDr78vzKAWcv6DDEZqRhhDyDtzgrZP6/`

Not really sure if we need the second version but safe origin gateways are not that many in comparison with unsafe origin ones according to https://ipfs.github.io/public-gateway-checker/