### PR TITLE
remove checks for a long domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.1
+* Fixed issue with long domain names. Now extension can resolve any length domain without a problem.
+
 ## 2.2.0
 * Added support for L2 domains on polygon
 

--- a/manifest-template.json
+++ b/manifest-template.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "Unstoppable Extension",
     "short_name": "Unstoppable Extension",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "description": "The Unstoppable Extension is used to access decentralized blockchain domains.",
     "icons": {
       "16": "icon/16.png",

--- a/src/util/isValidDNSHostname.ts
+++ b/src/util/isValidDNSHostname.ts
@@ -1,6 +1,5 @@
 const rules = {
     segmentMinLength: 2,
-    labelLength: 63,
     domainLength: 253,
     domainSegment: /^[a-zA-Z0-9\-](?:[a-zA-Z0-9\-]*[a-zA-Z0-9\-])?$/,
     tldSegment: /^[a-zA-Z](?:[a-zA-Z0-9\-]*[a-zA-Z0-9])?|[0-9]+$/,

--- a/src/util/isValidDNSHostname.ts
+++ b/src/util/isValidDNSHostname.ts
@@ -14,7 +14,7 @@ export default function isValidDNSHostname(hostname: string) {
   }
   return labels.every((label,i) => {
     if(i < labels.length - 1) {
-      return rules.domainSegment.test(label) && label.length <= rules.labelLength;
+      return rules.domainSegment.test(label);
     }
     return rules.tldSegment.test(label);
   })


### PR DESCRIPTION
This removes the check for longer domain names as blockchain domains names are not the same as traditional ones we don't really need such checks.