### PR TITLE
Fix not resolving of .888 domains on Windows OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.2.2
+* Fixed issue with resolving .888 domains on Windows OS
 ## 2.2.1
 * Fixed issue with long domain names. Now extension can resolve any length domain without a problem.
 

--- a/manifest-template.json
+++ b/manifest-template.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "Unstoppable Extension",
     "short_name": "Unstoppable Extension",
-    "version": "2.2.1",
+    "version": "2.2.2",
     "description": "The Unstoppable Extension is used to access decentralized blockchain domains.",
     "icons": {
       "16": "icon/16.png",

--- a/src/internalPages/ExtensionMain/MainScreen.tsx
+++ b/src/internalPages/ExtensionMain/MainScreen.tsx
@@ -41,11 +41,11 @@ const MainScreen: React.FC<Props> = ({classes}) => {
 
   useEffect(() => {
     try {
-      new URL(gatewayBaseURL.trim())
+      new OAURL(gatewayBaseURL.trim())
       setOkGatewayBaseURL(true)
     } catch (error) {
       try {
-        new URL('http://' + gatewayBaseURL.trim())
+        new OAURL('http://' + gatewayBaseURL.trim())
         setOkGatewayBaseURL(true)
       } catch (error) {
         setOkGatewayBaseURL(false)

--- a/src/scripts/background.ts
+++ b/src/scripts/background.ts
@@ -2,7 +2,7 @@ import '../subscripts/onInstalled'
 import isValidDNSHostname from '../util/isValidDNSHostname';
 import { redirectToIpfs, supportedDomain, supportedDomains } from '../util/helpers'
 import { searchEngines, SearchEngine } from '../util/searchEngines'
-
+import OAURL from '../util/OsAgnosticURL';
 chrome.webRequest.onBeforeRequest.addListener(
   requestDetails => {
     const url = new URL(requestDetails.url)
@@ -13,26 +13,25 @@ chrome.webRequest.onBeforeRequest.addListener(
       .get(searchEngine.param)
       .trim()
       .toLowerCase()
-    const q = new URL(url.protocol + '//' + params)
+    const q = new OAURL(url.protocol + '//' + params)
     if (
-      !q.hostname ||
-      !isValidDNSHostname(q.hostname) ||
-      !supportedDomain(q.hostname)
+      !q.hostname() ||
+      !isValidDNSHostname(q.hostname()) ||
+      !supportedDomain(q.hostname())
     ) {
       return
     }
 
-    if (q.hostname.endsWith('.888')) {
+    if (q.hostname().endsWith('.888')) {
       chrome.tabs.update(
         { url: 'index.html#loading' },
         async (tab: chrome.tabs.Tab) => {
-            await redirectToIpfs(`https://${q.hostname}`, tab.id)
+            await redirectToIpfs(q.toString(), tab.id)
           return { cancel: true }
         },
       )
       return {cancel: true}
     }
-
     chrome.tabs.update({ url: q.toString() })
     return { cancel: true }
   },

--- a/src/util/OsAgnosticURL.ts
+++ b/src/util/OsAgnosticURL.ts
@@ -1,0 +1,44 @@
+// on Windows OS new OAURL('http://anything.888') crashing the extension with 'Invalid URL' error
+// this OAURL class is a hacky attempt to bring both OS under the same page.
+
+export default class OAURL {
+
+  private isDigitTld: boolean;
+  private url: URL;
+
+  constructor(url: string) {
+    this.isDigitTld = url.includes('.888');
+    this.url = this.isDigitTld ? 
+      new URL(this.fromDot888ToDotCom(url)) :
+      new URL(url);
+  }
+
+  hostname(): string {
+    return this.isDigitTld ? this.fromDotComToDot888(this.url.hostname) : this.url.hostname;
+  }
+
+  protocol(): string {
+    return this.url.protocol;
+  }
+
+  pathname(): string {
+    return this.isDigitTld ? this.fromDotComToDot888(this.url.pathname) : this.url.pathname;
+  }
+
+  searchParams(): URLSearchParams {
+    return this.url.searchParams;
+  }
+
+  toString(): string {
+    return this.isDigitTld ? this.fromDotComToDot888(this.url.toString()) : this.url.toString();
+  }
+
+  private fromDotComToDot888(mes: string): string {
+    return mes.replace('.com', '.888');
+  }
+
+  private fromDot888ToDotCom(mes: string): string {
+    return mes.replace('.888', '.com');
+  }
+
+}


### PR DESCRIPTION
The issue was that `new URL()` objects behave differently on MAC OS and on Windows OS. 

new URL('http://example.888') is falling on Windows only with the error: 'Invalid URL'. 
I tried to use [url-polyfill](https://www.npmjs.com/package/url-polyfill)  package to bring the new URL to a common denominator between two OS, however, it didn't work.

Instead, I had to implement a small hacky class OAURL which works around this by replacing .888 in the URL object with .com for storage only. When asked for certain properties like pathname or hostname it takes the data from URL object and replaces .com with .888 to be consistent. 

This solution is not the prettiest, but it works. It also allows me to visit pages such as https://paulbloc8.888/testUrlPath

If someone knows a better solution please let me know. 