### PR TITLE
[UDM-174] Improve handling of unsupported commands in Connect.tsx window

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ud-extension",
-  "version": "3.1.25",
+  "version": "3.1.26",
   "license": "MIT",
   "author": {
     "email": "eng@unstoppabledomains.com",

--- a/src/pages/Wallet/Connect.tsx
+++ b/src/pages/Wallet/Connect.tsx
@@ -228,44 +228,60 @@ const Connect: React.FC = () => {
         }
 
         // handle the message
-        setConnectionStateMessage(message);
         switch (message.type) {
           case "accountRequest":
+            setConnectionStateMessage(message);
             setConnectionState(ConnectionState.CHAINID);
             handleGetAccount();
             break;
           case "chainIdRequest":
+            setConnectionStateMessage(message);
             setConnectionState(ConnectionState.CHAINID);
             handleGetChainId();
             break;
           case "requestPermissionsRequest":
+            setConnectionStateMessage(message);
             setConnectionState(ConnectionState.PERMISSIONS);
             break;
           case "selectAccountRequest":
+            setConnectionStateMessage(message);
             setConnectionState(ConnectionState.ACCOUNT);
             break;
           case "signMessageRequest":
+            setConnectionStateMessage(message);
             setConnectionState(ConnectionState.SIGN);
             handleSignMessage(message.params[0]);
             break;
           case "signTypedMessageRequest":
+            setConnectionStateMessage(message);
             setConnectionState(ConnectionState.SIGN);
             handleSignTypedMessage(message.params);
             break;
           case "sendTransactionRequest":
+            setConnectionStateMessage(message);
             setConnectionState(ConnectionState.SIGN);
             handleSendTransaction(message.params[0]);
             break;
           case "switchChainRequest":
+            setConnectionStateMessage(message);
             setConnectionState(ConnectionState.SWITCH_CHAIN);
             break;
           case "closeWindowRequest":
             handleClose();
             break;
+          // the following messages types can silently be ignored, as they
+          // are not relevant in the connect window
+          case "getPreferencesRequest":
+          case "newTabRequest":
+          case "queueRequest":
+          case "signInRequest":
+          case "xmtpReadyRequest":
+            return;
           default:
-            // unsupported method type
-            Logger.log("Unsupported message type", message);
-            throw new Error(UnsupportedRequestError);
+            // other unsupported method types can be ignored, but we'll show
+            // a warning message for visibility
+            Logger.warn("Ignoring unsupported message type", message);
+            return;
         }
 
         // add a listener for unload, which will detect if a user manually closes


### PR DESCRIPTION
As described in Linear ticket:
https://linear.app/unstoppable-domains/issue/UDM-174/multiple-calls-to-wallet-switchethereumnetwork-cause-connect-window-to

![image](https://github.com/user-attachments/assets/8c9b33d2-22de-4c9b-94ce-3bfca6730930)
