### PR TITLE
Add more error checking around sidePanel.open() logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 3.1.30
+* Update XMTP version to 12.1.0
+* Enhanced message spam protections
+* Open messages in browser side panel
+
+## 3.1.28
+* Reduce the set of required extension permissions
+* Make permissions optional where possible
+
 ## 3.1.25
 * Support for Unstoppable Lite Wallet, a wallet for domainers
 * Support for Unstoppable Messaging, powered by XMTP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 3.1.30
+## 3.1.31
 * Update XMTP version to 12.1.0
 * Enhanced message spam protections
 * Open messages in browser side panel
+* Messages context menu
 
 ## 3.1.28
 * Reduce the set of required extension permissions

--- a/manifest-template.json
+++ b/manifest-template.json
@@ -64,12 +64,12 @@
   "permissions": [
     "alarms",
     "declarativeNetRequest",
+    "sidePanel",
     "storage"
   ],
   "optional_permissions": [
     "contextMenus",
     "notifications",
-    "sidePanel",
     "tabs"
   ]
 }

--- a/manifest-template.json
+++ b/manifest-template.json
@@ -4,7 +4,7 @@
   "short_name": "Unstoppable Domains",
   "version": "<injected from package.json using create_manifest.js>",
   "description": "A crypto wallet for domainers: easily interact with onchain identities, assets and apps.",
-  "minimum_chrome_version": "102",
+  "minimum_chrome_version": "114",
   "icons": {
     "16": "icon/16.png",
     "38": "icon/38.png",
@@ -23,6 +23,9 @@
       "96": "icon/96.png",
       "128": "icon/128.png"
     }
+  },
+  "side_panel": {
+    "default_path": "index.html#messages"
   },
   "background": {
     "service_worker": "./scripts/background.ts",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@unstoppabledomains/config": "0.0.13",
-    "@unstoppabledomains/ui-components": "0.0.50-browser-extension.6",
+    "@unstoppabledomains/ui-components": "0.0.50-browser-extension.11",
     "@unstoppabledomains/ui-kit": "0.3.24",
     "async-mutex": "^0.5.0",
     "compare-versions": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@unstoppabledomains/config": "0.0.13",
-    "@unstoppabledomains/ui-components": "0.0.50-browser-extension.4",
+    "@unstoppabledomains/ui-components": "0.0.50-browser-extension.5",
     "@unstoppabledomains/ui-kit": "0.3.24",
     "async-mutex": "^0.5.0",
     "compare-versions": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ud-extension",
-  "version": "3.1.29",
+  "version": "3.1.30",
   "license": "MIT",
   "author": {
     "email": "eng@unstoppabledomains.com",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "react-dom": "^17.0.0",
     "react-query": "^3.39.3",
     "react-router-dom": "^6.23.1",
+    "rgb-hex": "^4.1.0",
     "ts-retry": "^5.0.1",
     "use-async-effect": "^2.2.7",
     "web3": "^4.11.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ud-extension",
-  "version": "3.1.30",
+  "version": "3.1.31",
   "license": "MIT",
   "author": {
     "email": "eng@unstoppabledomains.com",
@@ -41,7 +41,7 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@unstoppabledomains/config": "0.0.13",
-    "@unstoppabledomains/ui-components": "0.0.50-browser-extension.5",
+    "@unstoppabledomains/ui-components": "0.0.50-browser-extension.6",
     "@unstoppabledomains/ui-kit": "0.3.24",
     "async-mutex": "^0.5.0",
     "compare-versions": "^6.1.1",

--- a/src/lib/runtime.ts
+++ b/src/lib/runtime.ts
@@ -3,6 +3,7 @@ import Bluebird from "bluebird";
 import {XMTP_CONVERSATION_FLAG} from "../types/wallet/messages";
 import {StorageSyncKey, chromeStorageGet} from "./chromeStorage";
 import rgbHex from "rgb-hex";
+import {sleep} from "./wallet/sleep";
 
 export enum BadgeColor {
   Blue = "#1976d2",
@@ -169,15 +170,31 @@ export const createNotification = async (
   priority?: number,
 ) => {
   if (chrome.notifications) {
-    chrome.notifications.create(id, {
-      type: "basic",
-      title,
-      iconUrl: chrome.runtime.getURL("/icon/128.png"),
-      message,
-      isClickable: true,
-      contextMessage,
-      priority,
-    });
+    // a callback to determine when the notification is finished
+    let isComplete = false;
+    const callback = () => {
+      isComplete = true;
+    };
+
+    // request the notification to be created
+    chrome.notifications.create(
+      id,
+      {
+        type: "basic",
+        title,
+        iconUrl: chrome.runtime.getURL("/icon/128.png"),
+        message,
+        isClickable: true,
+        contextMessage,
+        priority,
+      },
+      callback,
+    );
+
+    // wait for complete
+    while (!isComplete) {
+      await sleep(250);
+    }
   }
 };
 

--- a/src/lib/runtime.ts
+++ b/src/lib/runtime.ts
@@ -10,7 +10,7 @@ export enum BadgeColor {
   Green = "#4caf50",
 }
 
-const permissions = ["contextMenus", "notifications", "sidePanel", "tabs"];
+const permissions = ["contextMenus", "notifications", "tabs"];
 
 export const hasOptionalPermissions = async (): Promise<boolean> => {
   return await chrome.permissions.contains({permissions});

--- a/src/lib/sherlock/contextMenu.ts
+++ b/src/lib/sherlock/contextMenu.ts
@@ -67,6 +67,7 @@ export class ContextMenu {
     chrome.contextMenus.create({
       id: `${MenuType.Messages}-${origin}`,
       title: "Open messages",
+      documentUrlPatterns: [`${origin}/*`],
     });
 
     // add selected text menu item

--- a/src/lib/sherlock/contextMenu.ts
+++ b/src/lib/sherlock/contextMenu.ts
@@ -9,7 +9,8 @@ import {
   setWalletPreferences,
 } from "../wallet/preferences";
 import {sendMessageToClient} from "../wallet/message";
-import {setIcon} from "../runtime";
+import {openSidePanel, setIcon} from "../runtime";
+import {currentFocussedWindowId} from "../../scripts/liteWalletProvider/background";
 
 const ORIGINS: Record<string, boolean> = {};
 
@@ -17,19 +18,20 @@ enum MenuType {
   Sherlock = "sherlock",
   Connection = "connection",
   SelectedText = "selectedText",
+  Messages = "messages",
 }
 
-// tabListener wraps a context menu instance and handles tab events
-const tabListener = (ctx: ContextMenu) => {
+// messageListener wraps a context menu instance and handles message events
+const messageListener = (ctx: ContextMenu) => {
   return (message: ProviderRequest) => {
-    ctx.handleTab(message);
+    ctx.handleMessage(message);
   };
 };
 
 // menuListener wraps a context menu instance and handles menu events
 const menuListener = (ctx: ContextMenu) => {
-  return (info: chrome.contextMenus.OnClickData) => {
-    ctx.handleMenu(info);
+  return async (info: chrome.contextMenus.OnClickData) => {
+    await ctx.handleMenu(info);
   };
 };
 
@@ -59,6 +61,12 @@ export class ContextMenu {
           documentUrlPatterns: [`${origin}/*`],
         });
       }
+    });
+
+    // add message menu item
+    chrome.contextMenus.create({
+      id: `${MenuType.Messages}-${origin}`,
+      title: "Open messages",
     });
 
     // add selected text menu item
@@ -104,6 +112,7 @@ export class ContextMenu {
         this.remove(origin, MenuType.Connection);
         this.remove(origin, MenuType.Sherlock);
         this.remove(origin, MenuType.SelectedText);
+        this.remove(origin, MenuType.Messages);
       }
 
       // create new context menu item
@@ -114,7 +123,7 @@ export class ContextMenu {
     }
   }
 
-  async handleTab(message: ProviderRequest) {
+  async handleMessage(message: ProviderRequest) {
     if (message?.type !== "newTabRequest") {
       return;
     }
@@ -145,15 +154,27 @@ export class ContextMenu {
     // handle the menu action
     switch (menuOptions[0]) {
       case MenuType.Sherlock:
-        this.handleSherlockMenu(menuOptions[1]);
+        await this.handleSherlockMenu(menuOptions[1]);
         break;
       case MenuType.Connection:
-        this.handleDisconnectMenu(menuOptions[1]);
+        await this.handleDisconnectMenu(menuOptions[1]);
+        break;
+      case MenuType.Messages:
+        await this.handleMessageMenu();
         break;
       case MenuType.SelectedText:
-        this.handleFindDomainMenu(info);
+        await this.handleFindDomainMenu(info);
         break;
     }
+  }
+
+  /* **********************
+   * Messages menu handling
+   * **********************/
+
+  async handleMessageMenu() {
+    console.log("AJQ opening", currentFocussedWindowId);
+    await openSidePanel({windowId: currentFocussedWindowId});
   }
 
   /* **********************
@@ -239,8 +260,8 @@ export class ContextMenu {
       this.clear();
       this.preferences = await getWalletPreferences();
 
-      // listen for page requests for context menu updates
-      chrome.runtime.onMessage.addListener(tabListener(this));
+      // listen for messages requesting context menu updates
+      chrome.runtime.onMessage.addListener(messageListener(this));
 
       // listen for context menu clicks
       chrome.contextMenus.onClicked.addListener(menuListener(this));

--- a/src/lib/xmtp/listener.ts
+++ b/src/lib/xmtp/listener.ts
@@ -16,6 +16,7 @@ import {
   createNotification,
   incrementBadgeCount,
   openSidePanel,
+  setBadgeCount,
 } from "../runtime";
 import {getReverseResolution} from "../resolver/resolver";
 import {getWalletPreferences} from "../wallet/preferences";
@@ -242,6 +243,7 @@ const handleNotificationClick = async (notificationId: string) => {
         address: xmtpChatId,
         windowId: currentFocussedWindowId,
       });
+      await setBadgeCount(0, BadgeColor.Blue);
       return;
     }
 

--- a/src/lib/xmtp/listener.ts
+++ b/src/lib/xmtp/listener.ts
@@ -11,10 +11,15 @@ import {
   chromeStorageGet,
   chromeStorageSet,
 } from "../chromeStorage";
-import {BadgeColor, createNotification, incrementBadgeCount} from "../runtime";
+import {
+  BadgeColor,
+  createNotification,
+  incrementBadgeCount,
+  openSidePanel,
+} from "../runtime";
 import {getReverseResolution} from "../resolver/resolver";
 import {getWalletPreferences} from "../wallet/preferences";
-import {XMTP_CONVERSATION_FLAG} from "../../types/wallet/messages";
+import {currentFocussedWindowId} from "../../scripts/liteWalletProvider/background";
 
 let xmtpClient: Client = null;
 const xmtpMutex = new Mutex();
@@ -230,11 +235,14 @@ const handleNotificationClick = async (notificationId: string) => {
     const idParts = notificationId.split("-");
     const xmtpChatId = idParts.length > 0 ? idParts[1] : undefined;
 
-    // if a conversation ID is specified, set the popup focus
+    // if a conversation ID is specified, open the conversation
+    // in the side panel
     if (xmtpChatId) {
-      await chrome.action.setPopup({
-        popup: `${defaultPopupUrl}?${XMTP_CONVERSATION_FLAG}=${xmtpChatId}`,
+      await openSidePanel({
+        address: xmtpChatId,
+        windowId: currentFocussedWindowId,
       });
+      return;
     }
 
     // get the default popup URL

--- a/src/lib/xmtp/listener.ts
+++ b/src/lib/xmtp/listener.ts
@@ -95,8 +95,8 @@ const waitForMessages = async () => {
   // notify the user of their signed in status
   await createNotification(
     "xmtp-chat-initialized",
-    "Unstoppable Messaging",
-    "You're signed in! Connect with friends using Unstoppable Messaging, powered by XMTP. Over 2 million onchain identities use XMTP for secure, private, and portable messaging.",
+    "Unstoppable Domains",
+    "Your inbox is ready to use, powered by XMTP. Click to chat with friends.",
     undefined,
     2,
   );

--- a/src/pages/Wallet/PermissionCta.tsx
+++ b/src/pages/Wallet/PermissionCta.tsx
@@ -1,16 +1,17 @@
-import React from "react";
+import React, {useState} from "react";
 import Typography from "@mui/material/Typography";
 import Box from "@mui/material/Box";
 import Paper from "@mui/material/Paper";
 import AddModeratorOutlinedIcon from "@mui/icons-material/AddModeratorOutlined";
 import Button from "@mui/material/Button";
+import LoadingButton from "@mui/lab/LoadingButton";
 import {useExtensionStyles} from "../../styles/extension.styles";
 import {useTranslationContext} from "@unstoppabledomains/ui-components";
 import {requestOptionalPermissions} from "../../lib/runtime";
 import Markdown from "markdown-to-jsx";
 
 interface PermissionCtaProps {
-  onPermissionGranted: () => void;
+  onPermissionGranted: () => Promise<void>;
 }
 
 export const PermissionCta: React.FC<PermissionCtaProps> = ({
@@ -18,16 +19,19 @@ export const PermissionCta: React.FC<PermissionCtaProps> = ({
 }) => {
   const {classes, cx} = useExtensionStyles();
   const [t] = useTranslationContext();
+  const [isLoading, setIsLoading] = useState(false);
 
   const handleCancel = () => {
     window.close();
   };
 
   const handleGrantClicked = async () => {
+    setIsLoading(true);
     const isGranted = await requestOptionalPermissions();
     if (isGranted) {
-      onPermissionGranted();
+      await onPermissionGranted();
     }
+    setIsLoading(false);
   };
 
   return (
@@ -62,14 +66,15 @@ export const PermissionCta: React.FC<PermissionCtaProps> = ({
           </Paper>
         </Box>
         <Box className={classes.contentContainer}>
-          <Button
+          <LoadingButton
             variant="contained"
             fullWidth
             className={classes.button}
             onClick={handleGrantClicked}
+            loading={isLoading}
           >
             Grant Permissions
-          </Button>
+          </LoadingButton>
           <Button
             variant="outlined"
             fullWidth

--- a/src/pages/Wallet/Wallet.tsx
+++ b/src/pages/Wallet/Wallet.tsx
@@ -269,16 +269,13 @@ const WalletComp: React.FC = () => {
           await setBadgeCount(0),
 
           // create a notification to indicate sign in was successful
-          createNotification(
+          await createNotification(
             `signIn${Date.now()}`,
             t("wallet.title"),
             t("wallet.readyToUse"),
             undefined,
             2,
           ),
-
-          // short delay to ensure notification processes
-          sleep(500),
         ]);
 
         // show the permission CTA and leave the window open if optional
@@ -315,8 +312,8 @@ const WalletComp: React.FC = () => {
 
   const handlePermissionGranted = async () => {
     // reload the extension after permissions granted
+    await sleep(1000);
     chrome.runtime.reload();
-    handleClose();
   };
 
   const handleLogout = async () => {

--- a/src/pages/Wallet/Wallet.tsx
+++ b/src/pages/Wallet/Wallet.tsx
@@ -440,7 +440,7 @@ const WalletComp: React.FC = () => {
   };
 
   const handleMessagePopoutClick = async (address?: string) => {
-    await openSidePanel(address);
+    await openSidePanel({address});
   };
 
   const handleMessagesClicked = async () => {

--- a/src/pages/Wallet/Wallet.tsx
+++ b/src/pages/Wallet/Wallet.tsx
@@ -311,9 +311,7 @@ const WalletComp: React.FC = () => {
   };
 
   const handlePermissionGranted = async () => {
-    // reload the extension after permissions granted
-    await sleep(1000);
-    chrome.runtime.reload();
+    handleClose();
   };
 
   const handleLogout = async () => {

--- a/src/scripts/liteWalletProvider/background.ts
+++ b/src/scripts/liteWalletProvider/background.ts
@@ -20,6 +20,9 @@ import {
   isResponseType,
 } from "../../types/wallet/provider";
 
+// keep track of the most recently focussed window ID
+export let currentFocussedWindowId: number = null;
+
 // keep track of the wallet extension popup window ID
 let extensionPopupWindowId: number = null;
 
@@ -302,6 +305,9 @@ const handleTabStatus = async (tab: chrome.tabs.Tab) => {
   if (!tab?.url || !tab.id) {
     return;
   }
+
+  // determine current window ID
+  currentFocussedWindowId = tab.windowId;
 
   // determine if tab is connected
   const hostname = new URL(tab.url).hostname;

--- a/yarn.lock
+++ b/yarn.lock
@@ -15105,6 +15105,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rgb-hex@npm:^4.1.0":
+  version: 4.1.0
+  resolution: "rgb-hex@npm:4.1.0"
+  checksum: 662dcc1e9016852a0cd28250edc68a6bcf5ad07bf0ab92c2419da79b3ad6880cf94cdf93412f035c88662e2b8482d6852171a3c015ed5eec031613740edd791e
+  languageName: node
+  linkType: hard
+
 "rimraf@npm:3.0.2":
   version: 3.0.2
   resolution: "rimraf@npm:3.0.2"
@@ -16918,6 +16925,7 @@ __metadata:
     react-dom: ^17.0.0
     react-query: ^3.39.3
     react-router-dom: ^6.23.1
+    rgb-hex: ^4.1.0
     rimraf: ^5.0.7
     stream-browserify: ^3.0.0
     stream-http: ^3.1.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -4906,9 +4906,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@unstoppabledomains/ui-components@npm:0.0.50-browser-extension.6":
-  version: 0.0.50-browser-extension.6
-  resolution: "@unstoppabledomains/ui-components@npm:0.0.50-browser-extension.6"
+"@unstoppabledomains/ui-components@npm:0.0.50-browser-extension.11":
+  version: 0.0.50-browser-extension.11
+  resolution: "@unstoppabledomains/ui-components@npm:0.0.50-browser-extension.11"
   dependencies:
     "@braintree/sanitize-url": ^6.0.4
     "@emotion/server": ^11.4.0
@@ -5007,7 +5007,7 @@ __metadata:
     "@unstoppabledomains/ui-kit": ^0.3.24
     notistack: ^2.0.5
     react-query: ^3.39.3
-  checksum: c3557172d44cba8fe050a15f901b228fe916d6fe5b4725670285a55f170987abe17174ab7d083b63f68f4488a52a8d1e6013d10498e51001d346cf26d7cc281c
+  checksum: db53ea85fbfad39de4130ed3193903a266e3369e3bc160521e097ad8388da79ed706b6f13d436ff53bf17bc54286ae2f0dde0266765f276b0f99b26e34bd3e88
   languageName: node
   linkType: hard
 
@@ -16893,7 +16893,7 @@ __metadata:
     "@types/react": ^17.0.0
     "@types/react-dom": ^17.0.0
     "@unstoppabledomains/config": 0.0.13
-    "@unstoppabledomains/ui-components": 0.0.50-browser-extension.6
+    "@unstoppabledomains/ui-components": 0.0.50-browser-extension.11
     "@unstoppabledomains/ui-kit": 0.3.24
     assert: ^2.1.0
     async-mutex: ^0.5.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -4906,9 +4906,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@unstoppabledomains/ui-components@npm:0.0.50-browser-extension.5":
-  version: 0.0.50-browser-extension.5
-  resolution: "@unstoppabledomains/ui-components@npm:0.0.50-browser-extension.5"
+"@unstoppabledomains/ui-components@npm:0.0.50-browser-extension.6":
+  version: 0.0.50-browser-extension.6
+  resolution: "@unstoppabledomains/ui-components@npm:0.0.50-browser-extension.6"
   dependencies:
     "@braintree/sanitize-url": ^6.0.4
     "@emotion/server": ^11.4.0
@@ -5007,7 +5007,7 @@ __metadata:
     "@unstoppabledomains/ui-kit": ^0.3.24
     notistack: ^2.0.5
     react-query: ^3.39.3
-  checksum: 558edeedddaed5a66ca0ac6d839920c642f0d41aeb440b07a4feb733e4b4a8d6fa5e7487e768037513db1290c2d0ac5e2acb6ca94c0124e7f2ab2b36f47f3c56
+  checksum: c3557172d44cba8fe050a15f901b228fe916d6fe5b4725670285a55f170987abe17174ab7d083b63f68f4488a52a8d1e6013d10498e51001d346cf26d7cc281c
   languageName: node
   linkType: hard
 
@@ -16893,7 +16893,7 @@ __metadata:
     "@types/react": ^17.0.0
     "@types/react-dom": ^17.0.0
     "@unstoppabledomains/config": 0.0.13
-    "@unstoppabledomains/ui-components": 0.0.50-browser-extension.5
+    "@unstoppabledomains/ui-components": 0.0.50-browser-extension.6
     "@unstoppabledomains/ui-kit": 0.3.24
     assert: ^2.1.0
     async-mutex: ^0.5.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -4906,9 +4906,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@unstoppabledomains/ui-components@npm:0.0.50-browser-extension.4":
-  version: 0.0.50-browser-extension.4
-  resolution: "@unstoppabledomains/ui-components@npm:0.0.50-browser-extension.4"
+"@unstoppabledomains/ui-components@npm:0.0.50-browser-extension.5":
+  version: 0.0.50-browser-extension.5
+  resolution: "@unstoppabledomains/ui-components@npm:0.0.50-browser-extension.5"
   dependencies:
     "@braintree/sanitize-url": ^6.0.4
     "@emotion/server": ^11.4.0
@@ -5007,7 +5007,7 @@ __metadata:
     "@unstoppabledomains/ui-kit": ^0.3.24
     notistack: ^2.0.5
     react-query: ^3.39.3
-  checksum: ddb232f0022a957d89c798fb90c8dea5d53bced4747a1c2b6f6a63d411a635c93345e513a1fc96bde33ebda5ee169740f7ad2c3c2f87c4a50efcb0bd232f3f58
+  checksum: 558edeedddaed5a66ca0ac6d839920c642f0d41aeb440b07a4feb733e4b4a8d6fa5e7487e768037513db1290c2d0ac5e2acb6ca94c0124e7f2ab2b36f47f3c56
   languageName: node
   linkType: hard
 
@@ -16886,7 +16886,7 @@ __metadata:
     "@types/react": ^17.0.0
     "@types/react-dom": ^17.0.0
     "@unstoppabledomains/config": 0.0.13
-    "@unstoppabledomains/ui-components": 0.0.50-browser-extension.4
+    "@unstoppabledomains/ui-components": 0.0.50-browser-extension.5
     "@unstoppabledomains/ui-kit": 0.3.24
     assert: ^2.1.0
     async-mutex: ^0.5.0


### PR DESCRIPTION
Adds addition validation and error handling around the `chrome.sidePanel.open()` call, which seems to be a little problematic. If there's a problem, fallback to the default behavior of opening content within the extension popup.