### PR TITLE
Move RPC calls to background service worker

### DIFF
--- a/src/lib/wallet/evm/provider.ts
+++ b/src/lib/wallet/evm/provider.ts
@@ -4,10 +4,14 @@ import config from "@unstoppabledomains/config";
 import {getProviderUrl} from "@unstoppabledomains/ui-components/lib/wallet/evm/provider";
 
 export const getWeb3Provider = (chainId: number) => {
+  // inspect configurations of supported chains
   const chainSymbol = Object.keys(config.BLOCKCHAINS).find(k => {
     return (
+      config.WALLETS.CHAINS.SEND.map(c =>
+        c.split("/")[0].toUpperCase(),
+      ).includes(k.toUpperCase()) &&
       config.BLOCKCHAINS[k as keyof typeof config.BLOCKCHAINS].CHAIN_ID ===
-      chainId
+        chainId
     );
   });
   if (!chainSymbol) {

--- a/src/types/wallet/provider.ts
+++ b/src/types/wallet/provider.ts
@@ -25,6 +25,13 @@ export const ProviderMethodsWithPrompt: ProviderMethod[] = [
   "eth_sendTransaction",
 ];
 
+export type RpcRequest =
+  | "call"
+  | "estimateGas"
+  | "getBlockNumber"
+  | "getTransaction"
+  | "getTransactionReceipt";
+
 // define required EIP-1193 events
 export type Eip1193Event =
   | "accountsChanged"
@@ -74,6 +81,7 @@ export const InternalMessageTypes = [
   "signInRequest",
   "xmtpReadyRequest",
   "prepareXmtpRequest",
+  "rpcRequest",
 ] as const;
 export type InternalRequestType = (typeof InternalMessageTypes)[number];
 export const isInternalRequestType = (v: string): v is InternalRequestType => {
@@ -113,7 +121,8 @@ export type ResponseType =
   | "getPreferencesResponse"
   | "getDomainProfileResponse"
   | "getResolutionResponse"
-  | "prepareXmtpResponse";
+  | "prepareXmtpResponse"
+  | "rpcResponse";
 export const isResponseType = (v: string): v is ResponseType => {
   return isExternalRequestType(v.replaceAll("Response", "Request"));
 };


### PR DESCRIPTION
Instead of making RPC calls from the frontend context, make the calls from the background worker. Calling from the front end can lead to inconsistent results due to CSP rules on the current website.