### PR TITLE
Add collectibles tab to home screen navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Release build history can be found on [GitHub](https://github.com/unstoppabledomains/resolution-browser-extension/releases).
 
+## 3.1.57
+* Add a collectibles tab to wallet home screen
+
 ## 3.1.56
 * Use secure cloud storage for wallet preferences for better cross-device UX
 * Add manual refresh button to home screen

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ud-extension",
-  "version": "3.1.56",
+  "version": "3.1.57",
   "license": "MIT",
   "author": {
     "email": "eng@unstoppabledomains.com",
@@ -53,7 +53,7 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@unstoppabledomains/config": "0.0.26",
-    "@unstoppabledomains/ui-components": "0.0.53-browser-extension.20",
+    "@unstoppabledomains/ui-components": "0.0.53-browser-extension.21",
     "@unstoppabledomains/ui-kit": "0.3.24",
     "abitype": "^1.0.6",
     "async-mutex": "^0.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6397,9 +6397,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@unstoppabledomains/ui-components@npm:0.0.53-browser-extension.20":
-  version: 0.0.53-browser-extension.20
-  resolution: "@unstoppabledomains/ui-components@npm:0.0.53-browser-extension.20"
+"@unstoppabledomains/ui-components@npm:0.0.53-browser-extension.21":
+  version: 0.0.53-browser-extension.21
+  resolution: "@unstoppabledomains/ui-components@npm:0.0.53-browser-extension.21"
   dependencies:
     "@braintree/sanitize-url": ^6.0.4
     "@emotion/server": ^11.4.0
@@ -6502,7 +6502,7 @@ __metadata:
     "@unstoppabledomains/ui-kit": ^0.3.24
     notistack: ^2.0.5
     react-query: ^3.39.3
-  checksum: 73fd6834117ce8d0b71e54d2dddf460a66dd84f6dc7ec15b8b74c0d9327bff09277bb566d28a01a330473560cd96da58e974131f502b1f71b0feb53358e48f3c
+  checksum: c08e878d61bbcac7f5233c6a55ab328f168501907c2eb4d0b5ca70f509e3825780fcda6951d2d3d1266781f004fb84eb24b3177d9a58c85998601d23c8890a30
   languageName: node
   linkType: hard
 
@@ -21223,7 +21223,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.39.0
     "@typescript-eslint/parser": ^5.39.0
     "@unstoppabledomains/config": 0.0.26
-    "@unstoppabledomains/ui-components": 0.0.53-browser-extension.20
+    "@unstoppabledomains/ui-components": 0.0.53-browser-extension.21
     "@unstoppabledomains/ui-kit": 0.3.24
     abitype: ^1.0.6
     assert: ^2.1.0


### PR DESCRIPTION
The homescreen footer nav bar now includes a collectibles button. Clicking the button takes the user to a collectibles gallery view, where NFT collections are displayed. The user can explore NFTs within the collection and view details.

## Screenshots
<img width="394" alt="image" src="https://github.com/user-attachments/assets/a7483616-e6bb-4f1f-a269-41c4ba2853fe" />
