### PR TITLE
Resolve preferences race condition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ src/manifest.json
 .env.production
 .yarn
 tsconfig.tsbuildinfo
+src/index.html

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ud-extension",
-  "version": "3.1.57.4",
+  "version": "3.1.57.5",
   "license": "MIT",
   "author": {
     "email": "eng@unstoppabledomains.com",

--- a/scripts/create_manifest.js
+++ b/scripts/create_manifest.js
@@ -35,7 +35,7 @@ switch (theme) {
     manifestTemplateStr = manifestTemplateStr.replace(/<description>/g, "A crypto wallet for domainers: easily interact with onchain identities, assets and apps.");
     break;
   case "upio":
-    manifestTemplateStr = manifestTemplateStr.replace(/<name>/g, "UP.io - watch your crypto grow up");
+    manifestTemplateStr = manifestTemplateStr.replace(/<name>/g, "UP.io – Watch your crypto grow up");
     manifestTemplateStr = manifestTemplateStr.replace(/<short_name>/g, "UP.io");
     manifestTemplateStr = manifestTemplateStr.replace(/<website>/g, "up.io");
     manifestTemplateStr = manifestTemplateStr.replace(/<description>/g, "Securely manage your digital assets with confidence and ease. Swap and trade tokens on Bitcoin, Ethereum, Solana, Base & Polygon.");

--- a/src/scripts/liteWalletProvider/main.ts
+++ b/src/scripts/liteWalletProvider/main.ts
@@ -1195,5 +1195,7 @@ const registerProviders = (walletPreferences: WalletPreferences) => {
 void evmWalletProvider.getPreferences().then(walletPreferences => {
   if (walletPreferences.AppConnectionsEnabled) {
     registerProviders(walletPreferences);
+  } else {
+    Logger.log("App connections disabled");
   }
 });

--- a/src/scripts/sherlockProvider/main.ts
+++ b/src/scripts/sherlockProvider/main.ts
@@ -5,9 +5,25 @@ import {Logger} from "../../lib/logger";
 import {ContextMenu} from "../../lib/sherlock/contextMenu";
 import {isEthAddress, isPartialAddress} from "../../lib/sherlock/matcher";
 import {scanForResolutions} from "../../lib/sherlock/scanner";
+import {sleep} from "../../lib/wallet/sleep";
 
 // check preferences to ensure desired behavior
-void window[WINDOW_PROPERTY_NAME]?.getPreferences().then(preferences => {
+const waitForPreferences = async () => {
+  let i = 0;
+  while (!window[WINDOW_PROPERTY_NAME]) {
+    await sleep(1000);
+    i++;
+    if (i > 30) {
+      Logger.log("Preferences not available after 30 seconds");
+      return undefined;
+    }
+  }
+  Logger.log("Retrieved wallet preferences");
+  return await window[WINDOW_PROPERTY_NAME].getPreferences();
+};
+
+// wait for the preferences to be available and then create a context menu
+void waitForPreferences()?.then(preferences => {
   // broadcast an event indicating this tab needs context menu update
   const contextMenu = new ContextMenu(preferences);
   contextMenu.broadcastTab();


### PR DESCRIPTION
Depending on load order of extension scripts, the context menus may fail to retrieve wallet preferences. This will cause the context menus to be dropped from the runtime on a given page.