### PR TITLE
Namespaced event handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Release build history can be found on [GitHub](https://github.com/unstoppabledom
 ## 3.1.58
 * Update UP.io manifest
 * Add unique package names for UP.io and Unstoppable Domains app versions
+* Add namespace to provider background events
 
 ## 3.1.57
 * Add a collectibles tab to wallet home screen

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ud-extension",
-  "version": "3.1.58",
+  "version": "3.1.58.1",
   "license": "MIT",
   "author": {
     "email": "eng@unstoppabledomains.com",

--- a/src/lib/sherlock/contextMenu.ts
+++ b/src/lib/sherlock/contextMenu.ts
@@ -1,5 +1,6 @@
 import config from "@unstoppabledomains/config";
 
+import extensionConfig from "../../config";
 import {currentFocussedWindowId} from "../../scripts/liteWalletProvider/background";
 import {WalletPreferences} from "../../types/wallet/preferences";
 import {ProviderEvent, ProviderRequest} from "../../types/wallet/provider";
@@ -95,7 +96,7 @@ export class ContextMenu {
       return;
     }
     document.dispatchEvent(
-      new ProviderEvent("newTabRequest", {
+      new ProviderEvent("newTabRequest", extensionConfig.extension.rdns, {
         detail: [window.location.origin.toLowerCase()],
       }),
     );

--- a/src/scripts/liteWalletProvider/background.ts
+++ b/src/scripts/liteWalletProvider/background.ts
@@ -98,7 +98,7 @@ export const backgroundEventListener = (
   }
 
   // log the incoming external event
-  Logger.log("Handling event start", JSON.stringify(request));
+  Logger.log("Observed event", JSON.stringify(request));
 
   // handle external request types
   if (isExternalRequestType(request.type)) {
@@ -111,6 +111,24 @@ export const backgroundEventListener = (
         // retrieve the hostname parameter from the request params, which can safely be
         // popped from the list since no other callers expect it
         const requestHost = request.params.pop();
+
+        // retrieve the target namespace from the request params, which can safely be
+        // popped from the list since no other callers expect it
+        const namespace = request.params.pop();
+
+        // validate the namespace matches the current background runtime, otherwise
+        // the request can be ignored
+        if (namespace !== config.extension.rdns) {
+          Logger.warn(
+            "Ignoring event from unknown namespace",
+            JSON.stringify({namespace, request}),
+          );
+          return;
+        }
+        Logger.log(
+          "Handling event from namespace",
+          JSON.stringify({namespace, request}),
+        );
 
         // scan the active tabs for the expected hostname of the calling application. This
         // data is used for context in the wallet extension popup window

--- a/src/scripts/liteWalletProvider/isolated.ts
+++ b/src/scripts/liteWalletProvider/isolated.ts
@@ -1,3 +1,4 @@
+import config from "../../config";
 import {
   ExternalMessageTypes,
   InternalMessageTypes,
@@ -26,9 +27,13 @@ import {
           isInternalRequestType(messageType)
         ) {
           document.dispatchEvent(
-            new ProviderEvent(getResponseType(messageType), {
-              detail: response,
-            }),
+            new ProviderEvent(
+              getResponseType(messageType),
+              config.extension.rdns,
+              {
+                detail: response,
+              },
+            ),
           );
         }
       },

--- a/src/scripts/liteWalletProvider/main.ts
+++ b/src/scripts/liteWalletProvider/main.ts
@@ -281,7 +281,9 @@ class LiteWalletProvider extends EventEmitter {
   async getPreferences(): Promise<WalletPreferences> {
     const fetcher = () =>
       new Promise<WalletPreferences>((resolve, reject) => {
-        document.dispatchEvent(new ProviderEvent("getPreferencesRequest"));
+        document.dispatchEvent(
+          new ProviderEvent("getPreferencesRequest", config.extension.rdns),
+        );
         this.addEventListener(
           "getPreferencesResponse",
           (event: ProviderResponse) => {
@@ -326,7 +328,11 @@ class LiteWalletProvider extends EventEmitter {
       return await new Promise<SerializedPublicDomainProfileData>(
         (resolve, reject) => {
           document.dispatchEvent(
-            new ProviderEvent("getDomainProfileRequest", {detail: [domain]}),
+            new ProviderEvent(
+              "getDomainProfileRequest",
+              config.extension.rdns,
+              {detail: [domain]},
+            ),
           );
           this.addEventListener(
             "getDomainProfileResponse",
@@ -371,7 +377,9 @@ class LiteWalletProvider extends EventEmitter {
       // retrieve the resolution data
       return await new Promise<ResolutionData>((resolve, reject) => {
         document.dispatchEvent(
-          new ProviderEvent("getResolutionRequest", {detail: [addressOrName]}),
+          new ProviderEvent("getResolutionRequest", config.extension.rdns, {
+            detail: [addressOrName],
+          }),
         );
         this.addEventListener(
           "getResolutionResponse",
@@ -460,12 +468,16 @@ class LiteWalletProvider extends EventEmitter {
 
   private handleQueueUpdate(count: number) {
     document.dispatchEvent(
-      new ProviderEvent("queueRequest", {detail: [count]}),
+      new ProviderEvent("queueRequest", config.extension.rdns, {
+        detail: [count],
+      }),
     );
   }
 
   private handleClosePopup() {
-    document.dispatchEvent(new ProviderEvent("closeWindowRequest"));
+    document.dispatchEvent(
+      new ProviderEvent("closeWindowRequest", config.extension.rdns),
+    );
   }
 
   private handleConnected(
@@ -502,7 +514,9 @@ class LiteWalletProvider extends EventEmitter {
     // a method to retrieve account data
     const fetcher = () =>
       new Promise<string>((resolve, reject) => {
-        document.dispatchEvent(new ProviderEvent("accountRequest"));
+        document.dispatchEvent(
+          new ProviderEvent("accountRequest", config.extension.rdns),
+        );
         this.addEventListener("accountResponse", (event: ProviderResponse) => {
           if (event.detail.error) {
             reject(
@@ -594,7 +608,9 @@ class LiteWalletProvider extends EventEmitter {
   ) {
     const rpcResponse = new Promise((resolve, reject) => {
       document.dispatchEvent(
-        new ProviderEvent("rpcRequest", {detail: [chainId, method, ...params]}),
+        new ProviderEvent("rpcRequest", config.extension.rdns, {
+          detail: [chainId, method, ...params],
+        }),
       );
       this.addEventListener("rpcResponse", (event: ProviderResponse) => {
         if (event.detail.error) {
@@ -630,7 +646,9 @@ class LiteWalletProvider extends EventEmitter {
     // a method to retrieve chain ID data
     const fetcher = () =>
       new Promise<number>((resolve, reject) => {
-        document.dispatchEvent(new ProviderEvent("chainIdRequest"));
+        document.dispatchEvent(
+          new ProviderEvent("chainIdRequest", config.extension.rdns),
+        );
         this.addEventListener("chainIdResponse", (event: ProviderResponse) => {
           if (event.detail.error) {
             reject(
@@ -670,7 +688,9 @@ class LiteWalletProvider extends EventEmitter {
 
     // connect to account
     const accountResponse = new Promise((resolve, reject) => {
-      document.dispatchEvent(new ProviderEvent("selectAccountRequest"));
+      document.dispatchEvent(
+        new ProviderEvent("selectAccountRequest", config.extension.rdns),
+      );
       this.addEventListener(
         "selectAccountResponse",
         (event: ProviderResponse) => {
@@ -706,7 +726,7 @@ class LiteWalletProvider extends EventEmitter {
   private async handleRequestPermissions(params: any[]) {
     return await new Promise((resolve, reject) => {
       document.dispatchEvent(
-        new ProviderEvent("requestPermissionsRequest", {
+        new ProviderEvent("requestPermissionsRequest", config.extension.rdns, {
           detail: params,
         }),
       );
@@ -759,7 +779,7 @@ class LiteWalletProvider extends EventEmitter {
     // if the chain is not available
     return await new Promise((resolve, reject) => {
       document.dispatchEvent(
-        new ProviderEvent("switchChainRequest", {
+        new ProviderEvent("switchChainRequest", config.extension.rdns, {
           detail: [{chainId: requestedChainId}],
         }),
       );
@@ -832,7 +852,7 @@ class LiteWalletProvider extends EventEmitter {
     return await new Promise((resolve, reject) => {
       // send the message signing event
       document.dispatchEvent(
-        new ProviderEvent("signMessageRequest", {
+        new ProviderEvent("signMessageRequest", config.extension.rdns, {
           // parameters are expected to be sent as first element of
           // the detail array
           detail: [messageToSign],
@@ -938,7 +958,7 @@ class LiteWalletProvider extends EventEmitter {
     return await new Promise((resolve, reject) => {
       // send the typed message signing event
       document.dispatchEvent(
-        new ProviderEvent("signTypedMessageRequest", {
+        new ProviderEvent("signTypedMessageRequest", config.extension.rdns, {
           detail: params,
         }),
       );
@@ -996,7 +1016,7 @@ class LiteWalletProvider extends EventEmitter {
     return await new Promise((resolve, reject) => {
       // send the prepared transaction signing event
       document.dispatchEvent(
-        new ProviderEvent("sendTransactionRequest", {
+        new ProviderEvent("sendTransactionRequest", config.extension.rdns, {
           // parameters are expected to be sent as first element of
           // the detail array
           detail: [normalizedParams],
@@ -1041,7 +1061,7 @@ class LiteWalletProvider extends EventEmitter {
     return await new Promise((resolve, reject) => {
       // send the message signing event
       document.dispatchEvent(
-        new ProviderEvent("signSolanaMessageRequest", {
+        new ProviderEvent("signSolanaMessageRequest", config.extension.rdns, {
           detail: [messageToSign],
         }),
       );
@@ -1084,9 +1104,13 @@ class LiteWalletProvider extends EventEmitter {
     return await new Promise((resolve, reject) => {
       // send the transaction event
       document.dispatchEvent(
-        new ProviderEvent("signSolanaTransactionRequest", {
-          detail: [txToSign, txSendOption],
-        }),
+        new ProviderEvent(
+          "signSolanaTransactionRequest",
+          config.extension.rdns,
+          {
+            detail: [txToSign, txSendOption],
+          },
+        ),
       );
       this.addEventListener(
         "signSolanaTransactionResponse",

--- a/src/types/wallet/provider.ts
+++ b/src/types/wallet/provider.ts
@@ -203,12 +203,14 @@ export interface ProviderDomainProfileResponse {
 export class ProviderEvent extends CustomEvent<ProviderEventParams> {
   constructor(
     typeName: ExternalRequestType | InternalRequestType | ResponseType,
+    namespace: string,
     init?: ProviderEventInit,
   ) {
     if (isExternalRequestType(typeName)) {
-      // append hostname to params
+      // append namespace and hostname to params
       const initParams = (init ? init.detail : []) as any[];
-      initParams.push(window.location.hostname);
+      initParams.push(namespace); // used to identify the specific extension instance
+      initParams.push(window.location.hostname); // used to identify the calling app
       init = {
         detail: initParams,
       };


### PR DESCRIPTION
Ensure multiple versions of the browser extensions can be installed concurrently, by adding a namespace parameter to all passed events. Background listeners will only handle events matching their own namespace.