### PR TITLE
Fix session unlock bug in connect modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Release build history can be found on [GitHub](https://github.com/unstoppabledom
 * Large transfer protection with 2FA
 * Update support landing page link
 * Fix Solana transaction creation bug
+* Fix wallet connection bug when session is locked
 
 ## 3.1.59
 * Upgrade to XMTP v3

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ud-extension",
-  "version": "3.1.60.2",
+  "version": "3.1.60.3",
   "license": "MIT",
   "author": {
     "email": "eng@unstoppabledomains.com",

--- a/src/pages/Wallet/Connect.tsx
+++ b/src/pages/Wallet/Connect.tsx
@@ -118,7 +118,7 @@ const Connect: React.FC = () => {
     setTxLockStatus,
     accessToken,
     setAccessToken,
-  } = useWeb3Context();
+  } = useWeb3Context({enforcePin: true});
   const fireblocksMessageSigner = useFireblocksMessageSigner();
   const {preferences} = usePreferences();
   const [errorMessage, setErrorMessage] = useState<string>();


### PR DESCRIPTION
In the wallet connect popop, the `enforcePin` boolean must be explicitly set to `true` to provide the user with a PIN unlock prompt. This was a change to the underlying hook and required an update in the client.