### PR TITLE
Clear connection request badges on open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Release build history can be found on [GitHub](https://github.com/unstoppabledom
 
 ## 3.1.61
 * Fix XMTP bug that prevents service worker from starting
+* Clear connection request badge notifications when extension is opened
 
 ## 3.1.60
 * Large transfer protection with 2FA

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ud-extension",
-  "version": "3.1.61",
+  "version": "3.1.61.1",
   "license": "MIT",
   "author": {
     "email": "eng@unstoppabledomains.com",
@@ -56,7 +56,7 @@
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
     "@unstoppabledomains/config": "0.0.27",
-    "@unstoppabledomains/ui-components": "0.0.53-browser-extension.32",
+    "@unstoppabledomains/ui-components": "0.0.53-browser-extension.33",
     "@unstoppabledomains/ui-kit": "0.3.24",
     "abitype": "^1.0.6",
     "async-mutex": "^0.5.0",

--- a/src/pages/Wallet/Wallet.tsx
+++ b/src/pages/Wallet/Wallet.tsx
@@ -288,6 +288,9 @@ const WalletComp: React.FC = () => {
       return;
     }
 
+    // handle unhandled connection badges
+    await handleConnectionBadges();
+
     // handle message notifications if necessary
     await handleUnreadMessages();
 
@@ -656,6 +659,17 @@ const WalletComp: React.FC = () => {
       await requestOptionalPermissions(request);
     }
     await handleRefreshBanner();
+  };
+
+  const handleConnectionBadges = async () => {
+    // determine if there is an unhandled connection request badge
+    const badgeCount = await getBadgeCount(BadgeColor.Green);
+    if (badgeCount === 0) {
+      return;
+    }
+
+    // clear the badge count
+    await setBadgeCount(0, BadgeColor.Green);
   };
 
   const handleUnreadMessages = async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6389,9 +6389,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@unstoppabledomains/ui-components@npm:0.0.53-browser-extension.32":
-  version: 0.0.53-browser-extension.32
-  resolution: "@unstoppabledomains/ui-components@npm:0.0.53-browser-extension.32"
+"@unstoppabledomains/ui-components@npm:0.0.53-browser-extension.33":
+  version: 0.0.53-browser-extension.33
+  resolution: "@unstoppabledomains/ui-components@npm:0.0.53-browser-extension.33"
   dependencies:
     "@braintree/sanitize-url": ^6.0.4
     "@emotion/server": ^11.4.0
@@ -6492,7 +6492,7 @@ __metadata:
     "@unstoppabledomains/ui-kit": ^0.3.24
     notistack: ^2.0.5
     react-query: ^3.39.3
-  checksum: 827b4bb498b60254d38e4d2c333563f0d107efc32cce1b67d9b17114905a32e93df5bb07da048148cad2e853f84cbeb8e2b6df5cd4adf8b4ed39d27b59f97592
+  checksum: 504e7a41007bb5c64ee6c9bdd453adad12141f5c7118f9b12f2fe9bc44e37126d5b734e4c2725fbca2dd81cbf11f435d99af660c56faf33036e8087cb34f47c4
   languageName: node
   linkType: hard
 
@@ -21165,7 +21165,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.39.0
     "@typescript-eslint/parser": ^5.39.0
     "@unstoppabledomains/config": 0.0.27
-    "@unstoppabledomains/ui-components": 0.0.53-browser-extension.32
+    "@unstoppabledomains/ui-components": 0.0.53-browser-extension.33
     "@unstoppabledomains/ui-kit": 0.3.24
     abitype: ^1.0.6
     assert: ^2.1.0


### PR DESCRIPTION
The green connection request badge can linger in some situations. It should be cleared when the extension is opened, similar to unread message notification badges.

## Screenshot
### Connection request badge
<img width="238" alt="image" src="https://github.com/user-attachments/assets/5aa4bb33-ee78-416e-ba65-aca6cbb5a8e0" />
