### PR TITLE
Disable sherlock assistant by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Release build history can be found on [GitHub](https://github.com/unstoppabledomains/resolution-browser-extension/releases).
 
+## 3.1.63
+* Disable the Sherlock feature by default
+
 ## 3.1.62
 * Support to transfer NFTs on EVM and Solana blockchains
 * Update XMTP version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ud-extension",
-  "version": "3.1.62.1",
+  "version": "3.1.63",
   "license": "MIT",
   "author": {
     "email": "eng@unstoppabledomains.com",

--- a/src/lib/sherlock/contextMenu.ts
+++ b/src/lib/sherlock/contextMenu.ts
@@ -186,31 +186,31 @@ export class ContextMenu {
   async handleSherlockMenu(origin: string) {
     // retrieve current preferences and initialize if needed
     this.preferences = await getWalletPreferences();
-    if (!this.preferences.Scanning?.IgnoreOrigins) {
+    if (!this.preferences.Sherlock?.IgnoreOrigins) {
       const defaultPreferences = getDefaultPreferences();
-      this.preferences.Scanning = {
+      this.preferences.Sherlock = {
         Enabled: true,
-        AllowOrigins: defaultPreferences.Scanning.AllowOrigins,
-        IgnoreOrigins: defaultPreferences.Scanning.IgnoreOrigins,
+        AllowOrigins: defaultPreferences.Sherlock.AllowOrigins,
+        IgnoreOrigins: defaultPreferences.Sherlock.IgnoreOrigins,
       };
     }
 
     // update current preferences
     if (this.isSherlockDisabled(origin)) {
       // enable sherlock
-      const ignoreOrigins = this.preferences.Scanning.IgnoreOrigins.filter(
+      const ignoreOrigins = this.preferences.Sherlock.IgnoreOrigins.filter(
         h => !h.toLowerCase().includes(origin.toLowerCase()),
       );
-      this.preferences.Scanning.Enabled = true;
-      this.preferences.Scanning.IgnoreOrigins = ignoreOrigins;
-      this.preferences.Scanning.AllowOrigins.push(origin.toLowerCase());
+      this.preferences.Sherlock.Enabled = true;
+      this.preferences.Sherlock.IgnoreOrigins = ignoreOrigins;
+      this.preferences.Sherlock.AllowOrigins.push(origin.toLowerCase());
     } else {
       // disable sherlock
-      const allowOrigins = this.preferences.Scanning.AllowOrigins.filter(
+      const allowOrigins = this.preferences.Sherlock.AllowOrigins.filter(
         h => !h.toLowerCase().includes(origin.toLowerCase()),
       );
-      this.preferences.Scanning.AllowOrigins = allowOrigins;
-      this.preferences.Scanning.IgnoreOrigins.push(origin.toLowerCase());
+      this.preferences.Sherlock.AllowOrigins = allowOrigins;
+      this.preferences.Sherlock.IgnoreOrigins.push(origin.toLowerCase());
     }
 
     // update menu and store preferences
@@ -221,13 +221,13 @@ export class ContextMenu {
   isSherlockDisabled(origin: string) {
     return (
       // scanning globally disabled
-      !this.preferences?.Scanning?.Enabled ||
+      !this.preferences?.Sherlock?.Enabled ||
       // host on the ignore list
-      this.preferences.Scanning.IgnoreOrigins?.find(h =>
+      this.preferences.Sherlock.IgnoreOrigins?.find(h =>
         origin.toLowerCase().includes(h.toLowerCase()),
       ) ||
       // host not on the allow list
-      !this.preferences.Scanning.AllowOrigins?.find(h => {
+      !this.preferences.Sherlock.AllowOrigins?.find(h => {
         if (origin.toLowerCase().includes(h.toLowerCase())) {
           return true;
         }

--- a/src/lib/wallet/preferences.ts
+++ b/src/lib/wallet/preferences.ts
@@ -28,12 +28,12 @@ export const getWalletPreferences = async (): Promise<WalletPreferences> => {
       if (basePreferences.MessagingEnabled === undefined) {
         basePreferences.MessagingEnabled = defaultPreferences.MessagingEnabled;
       }
-      if (basePreferences.Scanning === undefined) {
-        basePreferences.Scanning = defaultPreferences.Scanning;
+      if (basePreferences.Sherlock === undefined) {
+        basePreferences.Sherlock = defaultPreferences.Sherlock;
       }
-      if (basePreferences.Scanning.AllowOrigins === undefined) {
-        basePreferences.Scanning.AllowOrigins =
-          defaultPreferences.Scanning.AllowOrigins;
+      if (basePreferences.Sherlock.AllowOrigins === undefined) {
+        basePreferences.Sherlock.AllowOrigins =
+          defaultPreferences.Sherlock.AllowOrigins;
       }
       if (basePreferences.TwoFactorAuth === undefined) {
         basePreferences.TwoFactorAuth = defaultPreferences.TwoFactorAuth;
@@ -58,8 +58,8 @@ export const getDefaultPreferences = (): WalletPreferences => {
     VersionInfo: config.VERSION_DESCRIPTION,
     MessagingEnabled: true,
     AppConnectionsEnabled: false,
-    Scanning: {
-      Enabled: true,
+    Sherlock: {
+      Enabled: false, // disabled by default
       AllowOrigins: [
         // enable X by default
         "https://x.com",

--- a/src/pages/Legacy/Extension.tsx
+++ b/src/pages/Legacy/Extension.tsx
@@ -44,13 +44,13 @@ const Extension: React.FC = () => {
     }
 
     // initialize scanning preferences if required
-    if (!preferences.Scanning) {
+    if (!preferences.Sherlock) {
       const defaultPreferences = getDefaultPreferences();
-      preferences.Scanning = defaultPreferences.Scanning;
+      preferences.Sherlock = defaultPreferences.Sherlock;
     }
 
     // set the sherlock assistant preference
-    preferences.Scanning.Enabled = event.target.checked;
+    preferences.Sherlock.Enabled = event.target.checked;
     setPreferences({...preferences});
     await setWalletPreferences(preferences);
   };
@@ -75,7 +75,7 @@ const Extension: React.FC = () => {
                     label={`${t("manage.enable")} ${t("extension.sherlockAssistant")}`}
                     control={
                       <Checkbox
-                        checked={preferences?.Scanning?.Enabled}
+                        checked={preferences?.Sherlock?.Enabled}
                         onChange={handleSherlockAssistant}
                       />
                     }

--- a/src/pages/Wallet/Preferences.tsx
+++ b/src/pages/Wallet/Preferences.tsx
@@ -100,13 +100,13 @@ export const Preferences: React.FC<PreferencesProps> = ({onClose}) => {
     }
 
     // initialize scanning preferences if required
-    if (!preferences.Scanning) {
+    if (!preferences.Sherlock) {
       const defaultPreferences = getDefaultPreferences();
-      preferences.Scanning = defaultPreferences.Scanning;
+      preferences.Sherlock = defaultPreferences.Sherlock;
     }
 
     // set the sherlock assistant preference
-    preferences.Scanning.Enabled = event.target.checked;
+    preferences.Sherlock.Enabled = event.target.checked;
     setPreferences({...preferences});
     await setWalletPreferences(preferences);
   };
@@ -291,7 +291,7 @@ export const Preferences: React.FC<PreferencesProps> = ({onClose}) => {
                   title={t("extension.sherlockAssistant")}
                   description={t("extension.sherlockAssistantDescription")}
                   statusElement={renderStatus(
-                    preferences?.Scanning?.Enabled
+                    preferences?.Sherlock?.Enabled
                       ? t("common.on")
                       : t("common.off"),
                   )}
@@ -305,7 +305,7 @@ export const Preferences: React.FC<PreferencesProps> = ({onClose}) => {
                             ? "primary"
                             : "secondary"
                         }
-                        checked={preferences?.Scanning?.Enabled}
+                        checked={preferences?.Sherlock?.Enabled}
                         onChange={handleSherlockAssistant}
                       />
                     }

--- a/src/types/wallet/preferences.ts
+++ b/src/types/wallet/preferences.ts
@@ -6,7 +6,7 @@ export interface WalletPreferences {
   MessagingEnabled: boolean;
   AppConnectionsEnabled: boolean;
   OverrideMetamask: boolean;
-  Scanning: {
+  Sherlock: {
     Enabled: boolean;
     AllowOrigins: string[];
     IgnoreOrigins: string[];


### PR DESCRIPTION
Some users have experienced website compatibility issues when using the Sherlock Assistant feature. To address this, we have disabled the Sherlock Assistant by default in this release. It is now an opt-in feature.