### PR TITLE
Load wallet into DOM slightly later in page load

### DIFF
--- a/manifest-template.json
+++ b/manifest-template.json
@@ -36,13 +36,13 @@
       "matches": ["<all_urls>"],
       "js": ["./scripts/liteWalletProvider/main.ts"],
       "world": "MAIN",
-      "run_at": "document_start"
+      "run_at": "document_end"
     }, 
     {
       "matches": ["<all_urls>"],
       "js": ["./scripts/liteWalletProvider/isolated.ts"],
       "world": "ISOLATED",
-      "run_at": "document_start"
+      "run_at": "document_end"
     },
     {
       "matches": ["<all_urls>"],
@@ -60,7 +60,6 @@
       "resources": ["./scripts/contentIsolated.ts", "index.html", "icon/*", "icon/udme/*", "icon/upio/*"]
     }
   ],
-  "host_permissions": ["<all_urls>"],
   "permissions": [
     "alarms",
     "sidePanel",
@@ -69,7 +68,6 @@
   ],
   "optional_permissions": [
     "contextMenus",
-    "declarativeNetRequestWithHostAccess",
     "notifications"
   ]
 }


### PR DESCRIPTION
Change to `document_end` vs `document_start` to avoid some page load conflicts.