### PR TITLE
Enable optional permission declarativeNetRequestWithHostAccess for web3 browsing

### DIFF
--- a/manifest-template.json
+++ b/manifest-template.json
@@ -60,6 +60,7 @@
       "resources": ["./scripts/contentIsolated.ts", "index.html", "icon/*", "icon/udme/*", "icon/upio/*"]
     }
   ],
+  "host_permissions": ["<all_urls>"],
   "permissions": [
     "alarms",
     "sidePanel",
@@ -68,6 +69,7 @@
   ],
   "optional_permissions": [
     "contextMenus",
+    "declarativeNetRequestWithHostAccess",
     "notifications"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ud-extension",
-  "version": "3.1.63.2",
+  "version": "3.1.63.3",
   "license": "MIT",
   "author": {
     "email": "eng@unstoppabledomains.com",


### PR DESCRIPTION
The permission was removed by mistake in a previous PR. Restoring the previously used permission.