### PR TITLE
chore: simplify AI review workflow triggers

### DIFF
--- a/.github/workflows/ai-review-bot.yml
+++ b/.github/workflows/ai-review-bot.yml
@@ -2,12 +2,11 @@ name: AI Review Bot
 
 on:
   pull_request:
-    types: [labeled, unlabeled, review_requested]
+    types: [opened]
 
 permissions:
   contents: read
   pull-requests: write
-  issues: write
 
 jobs:
   ai-review-bot:

--- a/.github/workflows/ai-review-gate.yml
+++ b/.github/workflows/ai-review-gate.yml
@@ -1,22 +1,13 @@
 name: AI Review Gate
 
 on:
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-      - labeled
-      - unlabeled
   pull_request_review:
-    types:
-      - submitted
-      - dismissed
+    types: [submitted]
 
 permissions:
   contents: read
   pull-requests: write
-  issues: write
+  issues: write  # required for ai-review-approved label
 
 jobs:
   ai-review-gate:


### PR DESCRIPTION
## Summary

Updates the AI review bot and gate caller workflows to match the simplified triggers from [agent-plugins PR #98](https://github.com/unstoppabledomains/agent-plugins/pull/98).

**Changes:**
- **Gate**: Only triggers on `pull_request_review: [submitted]` (removes `labeled`, `unlabeled`, `synchronize`, `reopened`, `dismissed`)
- **Bot**: Only triggers on `pull_request: [opened]` (removes `labeled`, `unlabeled`, `review_requested`)
- **Gate**: Adds `issues: write` permission for `ai-review-approved` label
- **Bot**: Removes `issues: write` permission (no longer needed)

## Why

The reusable workflows no longer use labels for LLM-driven approval. The old triggers caused unnecessary workflow runs.

## Test plan

- [ ] Gate fires on PR review submission and auto-approves when AI review scores >= 8
- [ ] Bot posts instructions comment on PR open
- [ ] No unnecessary workflow runs on label/synchronize events